### PR TITLE
Update nostr.go

### DIFF
--- a/nostr/nostr.go
+++ b/nostr/nostr.go
@@ -21,6 +21,7 @@ const (
 var defaultRelays = []string{
 	// "ws://127.0.0.1:7001",
 
+	"wss://yabu.me",
 	"wss://relay.nostr.wirednet.jp",
 	"wss://relay-jp.nostr.wirednet.jp",
 	"wss://nostr.h3z.jp",


### PR DESCRIPTION
Add yabu.me relay.

日本のNostrユーザーの中で一番利用者が多い＆安定していると思う、yabu.meリレーをイベント転送先として追加したいです。